### PR TITLE
Feat: Add utility-types package and implement Optional type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "dayjs": "^1.11.18",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "sass": "^1.91.0"
+        "sass": "^1.91.0",
+        "utility-types": "^3.11.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -5091,6 +5092,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dayjs": "^1.11.18",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "sass": "^1.91.0"
+    "sass": "^1.91.0",
+    "utility-types": "^3.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/appointmentItem.tsx/AppointmentItem.tsx
+++ b/src/components/appointmentItem.tsx/AppointmentItem.tsx
@@ -1,14 +1,18 @@
 import { useState, useEffect } from "react";
 import "./appointmentItem.scss";
-import type { ActiveAppointment } from "../../shared/interfaces/appointment.interface";
+import type { IAppointment } from "../../shared/interfaces/appointment.interface";
 import dayjs from "dayjs";
+import { type Optional } from "utility-types";
+
+type AppointmentProps = Optional<IAppointment, 'canceled'>;
 
 function AppointmentItem({
 	name,
 	date,
 	service,
 	phone,
-}: ActiveAppointment) {
+	canceled
+}: AppointmentProps) {
 
 	const [timeLeft, changeTimeLeft] = useState<string | null>(null);
 
@@ -33,12 +37,16 @@ function AppointmentItem({
 				<span className="appointment__service">Service: {service}</span>
 				<span className="appointment__phone">Phone: {phone}</span>
 			</div>
-			<div className="appointment__time">
-				<span>Time left:</span>
-				<span className="appointment__timer">{timeLeft}</span>
-			</div>
-			<button className="appointment__cancel">Cancel</button>
-			{/* <div className="appointment__canceled">Canceled</div> */}
+			{!canceled ? (
+				<>
+					<div className="appointment__time">
+						<span>Time left:</span>
+						<span className="appointment__timer">{timeLeft}</span>
+					</div>
+					<button className="appointment__cancel">Cancel</button>
+				</>
+			) : null}
+			{canceled ? <div className="appointment__canceled">Canceled</div> : null}
 		</div>
 	);
 }


### PR DESCRIPTION
## Что было сделано?

1. **Добавлена новая зависимость:**
   - `utility-types@^3.11.0` - для advanced TypeScript утилит

2. **Рефактор компонента AppointmentItem:**
   - Использован `Optional` тип для пропса `canceled`
   - Компонент теперь можно использовать как с пропсом `canceled`, так и без него
   - Улучшена переиспользуемость между страницами

## Почему это важно?

- Устраняет дублирование кода
- Делает компонент более гибким
- Соответствует принципам TypeScript best practices

## Проверка

- [x] Пакет установлен корректно
- [x] Компонент работает с пропсом `canceled`
- [x] Компонент работает без пропса `canceled`
- [x] Таймер продолжает работать корректно